### PR TITLE
chore: resolve security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "@types/node": "^25.0.9",
         "astro": "^5.16.11",
         "astro-icon": "^1.1.5",
-        "tailwindcss": "^3.4.19"
+        "tailwindcss": "^3.4.19",
+        "undici": "7.18.2"
     },
     "devDependencies": {
         "@astrojs/check": "^0.9.6",
@@ -27,5 +28,10 @@
         "sharp": "^0.34.5",
         "typescript": "^5.9.3",
         "wrangler": "^4.59.2"
+    },
+    "pnpm": {
+        "overrides": {
+            "undici": "7.18.2"
+        }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: 7.18.2
+
 importers:
 
   .:
@@ -29,6 +32,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(yaml@2.8.2)
+      undici:
+        specifier: 7.18.2
+        version: 7.18.2
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.6
@@ -2611,10 +2617,6 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.14.0:
-    resolution: {integrity: sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
     engines: {node: '>=20.18.1'}
@@ -5099,7 +5101,7 @@ snapshots:
       glob-to-regexp: 0.4.1
       sharp: 0.33.5
       stoppable: 1.1.0
-      undici: 7.14.0
+      undici: 7.18.2
       workerd: 1.20251118.0
       ws: 8.18.0
       youch: 4.1.0-beta.10
@@ -5112,7 +5114,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.14.0
+      undici: 7.18.2
       workerd: 1.20260114.0
       ws: 8.18.0
       youch: 4.1.0-beta.10
@@ -5746,8 +5748,6 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
-
-  undici@7.14.0: {}
 
   undici@7.18.2: {}
 


### PR DESCRIPTION
## Security Updates

Resolves Dependabot alert: #58

### Changes
- Bump undici from 7.14.0 to 7.18.2 (low severity)
- Add pnpm override to force patched version across transitive dependencies

### Verification
- [ ] Tests pass
- [ ] No breaking changes
- [ ] Audit clean: `pnpm audit`